### PR TITLE
tcs.TrySetResult used instead of tcs.SetResult to avoid crash

### DIFF
--- a/Chance.MvvmCross.Plugins.UserInteraction.Touch/UserInteraction.cs
+++ b/Chance.MvvmCross.Plugins.UserInteraction.Touch/UserInteraction.cs
@@ -35,7 +35,7 @@ namespace Chance.MvvmCross.Plugins.UserInteraction.Touch
 		public Task<bool> ConfirmAsync(string message, string title = "", string okButton = "OK", string cancelButton = "Cancel")
 		{
 			var tcs = new TaskCompletionSource<bool>();
-			Confirm(message, tcs.SetResult, title, okButton, cancelButton);
+			Confirm(message, tcs.TrySetResult, title, okButton, cancelButton);
 			return tcs.Task;
         }
 
@@ -61,9 +61,8 @@ namespace Chance.MvvmCross.Plugins.UserInteraction.Touch
 
         public Task<ConfirmThreeButtonsResponse> ConfirmThreeButtonsAsync(string message, string title = null, string positive = "Yes", string negative = "No", string neutral = "Maybe")
         {
-
             var tcs = new TaskCompletionSource<ConfirmThreeButtonsResponse>();
-            ConfirmThreeButtons(message, tcs.SetResult, title, positive, negative, neutral);
+            ConfirmThreeButtons(message, tcs.TrySetResult, title, positive, negative, neutral);
             return tcs.Task;
         }
 
@@ -84,7 +83,7 @@ namespace Chance.MvvmCross.Plugins.UserInteraction.Touch
 		public Task AlertAsync(string message, string title = "", string okButton = "OK")
 		{
 			var tcs = new TaskCompletionSource<object>();
-			Alert(message, () => tcs.SetResult(null), title, okButton);
+			Alert(message, () => tcs.TrySetResult(null), title, okButton);
 			return tcs.Task;
         }
 
@@ -120,7 +119,7 @@ namespace Chance.MvvmCross.Plugins.UserInteraction.Touch
 		public Task<InputResponse> InputAsync(string message, string placeholder = null, string title = null, string okButton = "OK", string cancelButton = "Cancel", string initialText = null)
 		{
 			var tcs = new TaskCompletionSource<InputResponse>();
-			Input(message, (ok, text) => tcs.SetResult(new InputResponse {Ok = ok, Text = text}),	placeholder, title, okButton, cancelButton, initialText);
+			Input(message, (ok, text) => tcs.TrySetResult(new InputResponse {Ok = ok, Text = text}),	placeholder, title, okButton, cancelButton, initialText);
 			return tcs.Task;
 		}
 	}


### PR DESCRIPTION
I'm receiving rare crash reports related tcs.SetResult. It looks like there are cases when user either typed twice on the button (due to some device lag or something) or because the system calls OnClick event twice.

In any case it's looks like a good solution to use tcs.TrySetResult instead of tcs.SetResult to avoid crashes.

```
System.InvalidOperationExceptionThe underlying Task is already in one of the three final states: RanToCompletion, Faulted, or Canceled.

at System.Threading.Tasks.TaskCompletionSource`1[System.Boolean].SetResult (Boolean result)
at Chance.MvvmCross.Plugins.UserInteraction.Touch.UserInteraction+<Confirm>c__AnonStorey1+<Confirm>c__AnonStorey2.<>m__0 (System.Object sender, UIKit.UIButtonEventArgs args)
at UIKit.UIAlertView+_UIAlertViewDelegate.Clicked (UIKit.UIAlertView alertview, nint buttonIndex) 
...
```